### PR TITLE
Update Dockerfile: pin onnx tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,6 +148,7 @@ RUN ldconfig
 
 # Clone and build ONNX C++ library
 RUN git clone --recursive --depth 1 https://github.com/onnx/onnx.git /tmp/onnx
+RUN cd /tmp/onnx && git fetch --tags && git checkout tags/v1.16.2
 RUN mkdir -p /tmp/onnx/build && cd /tmp/onnx/build && cmake .. && make && make install
 
 # Clone and build Casadi


### PR DESCRIPTION
Pinned onnx tag since it wouldn't build as it wanted a cmake version that is too modern than what is available in the container